### PR TITLE
Add multiple indexes and index encoding for RAMI

### DIFF
--- a/src/LVMIndex.cpp
+++ b/src/LVMIndex.cpp
@@ -14,9 +14,9 @@
  *
  ***********************************************************************/
 
-#include "Util.h"
 #include "LVMIndex.h"
 #include "CompiledIndexUtils.h"
+#include "Util.h"
 
 namespace souffle {
 
@@ -138,17 +138,17 @@ public:
     }
 
     bool contains(const TupleRef&, const TupleRef&) const override {
-		return present;
-	}
+        return present;
+    }
 
     Stream scan() const override {
         return std::make_unique<Source>(present);
     }
 
     PartitionedStream pscan(int) const override {
-    	std::vector<Stream> res;
-    	res.push_back(scan());
-    	return res;
+        std::vector<Stream> res;
+        res.push_back(scan());
+        return res;
     }
 
     Stream range(const TupleRef& low, const TupleRef& high) const override {
@@ -156,9 +156,9 @@ public:
     }
 
     PartitionedStream prange(const TupleRef& low, const TupleRef& high, int) const override {
-    	std::vector<Stream> res;
-    	res.push_back(range(low,high));
-    	return res;
+        std::vector<Stream> res;
+        res.push_back(range(low, high));
+        return res;
     }
 
     void clear() override {
@@ -184,7 +184,7 @@ class GenericIndex : public LVMIndex {
     // the internal data structure
     Structure data;
 
-	using iter = typename Structure::iterator;
+    using iter = typename Structure::iterator;
 
     // a source adapter for streaming through data
     class Source : public Stream::Source {
@@ -249,62 +249,60 @@ public:
     }
 
     bool contains(const TupleRef& low, const TupleRef& high) const override {
-		return !bounds(low,high).empty();
-	}
+        return !bounds(low, high).empty();
+    }
 
     Stream scan() const override {
         return std::make_unique<Source>(order, data.begin(), data.end());
     }
 
     PartitionedStream pscan(int num_partitions) const override {
-    	auto chunks = data.partition(num_partitions);
-    	std::vector<Stream> res;
-    	res.reserve(chunks.size());
-    	for (const auto& cur : chunks) {
-    		res.push_back(std::make_unique<Source>(order, cur.begin(), cur.end()));
-    	}
-    	return res;
+        auto chunks = data.partition(num_partitions);
+        std::vector<Stream> res;
+        res.reserve(chunks.size());
+        for (const auto& cur : chunks) {
+            res.push_back(std::make_unique<Source>(order, cur.begin(), cur.end()));
+        }
+        return res;
     }
 
 private:
-
     souffle::range<iter> bounds(const TupleRef& low, const TupleRef& high) const {
-    	Entry a = order.encode(low.asTuple<Arity>());
-		Entry b = order.encode(high.asTuple<Arity>());
-		// Transfer upper_bound to a equivalent lower bound
-		bool fullIndexSearch = true;
-		for (size_t i = Arity; i-- > 0;) {
-			if (a[i] == MIN_RAM_DOMAIN && b[i] == MAX_RAM_DOMAIN) {
-				b[i] = MIN_RAM_DOMAIN;
-				continue;
-			}
-			if (a[i] == b[i]) {
-				b[i] += 1;
-				fullIndexSearch = false;
-				break;
-			}
-		}
-		if (fullIndexSearch) {
-			b[Arity-1]++;
-		}
-		return { data.lower_bound(a), data.lower_bound(b) };
+        Entry a = order.encode(low.asTuple<Arity>());
+        Entry b = order.encode(high.asTuple<Arity>());
+        // Transfer upper_bound to a equivalent lower bound
+        bool fullIndexSearch = true;
+        for (size_t i = Arity; i-- > 0;) {
+            if (a[i] == MIN_RAM_DOMAIN && b[i] == MAX_RAM_DOMAIN) {
+                b[i] = MIN_RAM_DOMAIN;
+                continue;
+            }
+            if (a[i] == b[i]) {
+                b[i] += 1;
+                fullIndexSearch = false;
+                break;
+            }
+        }
+        if (fullIndexSearch) {
+            b[0] = MAX_RAM_DOMAIN;
+        }
+        return {data.lower_bound(a), data.lower_bound(b)};
     }
 
 public:
-
     Stream range(const TupleRef& low, const TupleRef& high) const override {
-    	auto range = bounds(low, high);
+        auto range = bounds(low, high);
         return std::make_unique<Source>(order, range.begin(), range.end());
     }
 
     PartitionedStream prange(const TupleRef& low, const TupleRef& high, int num_partitions) const override {
-    	auto range = bounds(low, high);
-    	std::vector<Stream> res;
-    	res.reserve(num_partitions);
-    	for (const auto& cur : range.partition(num_partitions)) {
-    		res.push_back(std::make_unique<Source>(order, cur.begin(), cur.end()));
-    	}
-    	return res;
+        auto range = bounds(low, high);
+        std::vector<Stream> res;
+        res.reserve(num_partitions);
+        for (const auto& cur : range.partition(num_partitions)) {
+            res.push_back(std::make_unique<Source>(order, cur.begin(), cur.end()));
+        }
+        return res;
     }
 
     void clear() override {
@@ -415,19 +413,19 @@ public:
     }
 
     bool contains(const TupleRef& low, const TupleRef& high) const override {
-    	assert(false && "Not implemented!");
-		return false;
-	}
+        assert(false && "Not implemented!");
+        return false;
+    }
 
     Stream scan() const override {
         return std::make_unique<Source>(set.begin(), set.end());
     }
 
     PartitionedStream pscan(int) const override {
-    	assert(false && "Does only produce a single subset!");
-    	std::vector<Stream> res;
-    	res.push_back(scan());
-    	return res;
+        assert(false && "Does only produce a single subset!");
+        std::vector<Stream> res;
+        res.push_back(scan());
+        return res;
     }
 
     Stream range(const TupleRef& low, const TupleRef& high) const override {
@@ -435,10 +433,10 @@ public:
     }
 
     PartitionedStream prange(const TupleRef& low, const TupleRef& high, int) const override {
-    	assert(false && "Does only produce a single subset!");
-    	std::vector<Stream> res;
-		res.push_back(range(low,high));
-		return res;
+        assert(false && "Does only produce a single subset!");
+        std::vector<Stream> res;
+        res.push_back(range(low, high));
+        return res;
     }
 
     void clear() override {


### PR DESCRIPTION
My editor automatically reformated the coding style to follow Souffle's clang-format. So sorry for the messy commit history.

Changes are done in `RAMI.h` and `RAMI.cpp`. Also, a small correctness fix in `LVMIndex.cpp` line no.287.
